### PR TITLE
http-client/test-nonet: fix test after our hacks

### DIFF
--- a/http-client/test-nonet/Network/HTTP/ClientSpec.hs
+++ b/http-client/test-nonet/Network/HTTP/ClientSpec.hs
@@ -243,6 +243,7 @@ spec = describe "Client" $ do
           (return S.empty)
           (const checkStatus)
           (checkStatus >> writeIORef closedRef True)
+          False
 
         Internal.connectionClose conn
 


### PR DESCRIPTION
`stack test` now passes.

The following test did not compile before:

```
http-client        > build (lib + test)
http-client        > Preprocessing library for http-client-0.5.13..
http-client        > Building library for http-client-0.5.13..
http-client        > Preprocessing test suite 'spec-nonet' for http-client-0.5.13..
http-client        > Building test suite 'spec-nonet' for http-client-0.5.13..
http-client        > [7 of 8] Compiling Network.HTTP.ClientSpec
http-client        > 
http-client        > /work/http-client/http-client/test-nonet/Network/HTTP/ClientSpec.hs:242:17: error:
http-client        >     • Couldn't match expected type ‘IO Internal.Connection’
http-client        >                   with actual type ‘a0 -> IO Internal.Connection’
http-client        >     • Probable cause: ‘makeConnection’ is applied to too few arguments
http-client        >       In a stmt of a 'do' block:
http-client        >         conn <- makeConnection
http-client        >                   (return S.empty)
http-client        >                   (const checkStatus)
http-client        >                   (checkStatus >> writeIORef closedRef True)
http-client        >       In the second argument of ‘($)’, namely
http-client        >         ‘do closedRef <- newIORef False
http-client        >             okRef <- newIORef True
http-client        >             let checkStatus = ...
http-client        >             conn <- makeConnection
http-client        >                       (return S.empty)
http-client        >                       (const checkStatus)
http-client        >                       (checkStatus >> writeIORef closedRef True)
http-client        >             ....’
http-client        >       In a stmt of a 'do' block:
http-client        >         it "should not write to closed connection"
http-client        >           $ do closedRef <- newIORef False
http-client        >                okRef <- newIORef True
http-client        >                let checkStatus = ...
http-client        >                conn <- makeConnection
http-client        >                          (return S.empty)
http-client        >                          (const checkStatus)
http-client        >                          (checkStatus >> writeIORef closedRef True)
http-client        >                ....
http-client        >     |
http-client        > 242 |         conn <- makeConnection
http-client        >     |                 ^^^^^^^^^^^^^^...
http-client        > 
```

Because we change the signature of makeConnection in our fork.